### PR TITLE
Adjust copypaste plugin to use pyperclip instead

### DIFF
--- a/server/linux_x11/plugins/copypaste.py
+++ b/server/linux_x11/plugins/copypaste.py
@@ -1,23 +1,22 @@
 from yapsy.IPlugin import IPlugin
-from subprocess32 import check_output
+from subprocess32 import check_output, Popen, PIPE
 import os
 
 enabled = True
 
-def write_command(message, arguments='type --file -',
-                  executable=None):
-    with os.popen('%s %s' % (executable, arguments), 'w') as fd:
-        fd.write(message)
 
-def paste(text='default'):
-    write_command(text, arguments='-b', executable='xsel')
-    # server.key_press(key="v", modifiers=("control"))
+def copy(text):
+    with os.popen('python -m pyperclip -c', 'w') as fd:
+        fd.write(text)
 
-def copy():
-    text = check_output("xsel", shell=True)
+
+def paste():
+    text = check_output(['python', '-m', 'pyperclip', '-p'])
     return text
+
 
 class CopypastePlugin(IPlugin):
     def register_rpcs(self, server):
         server.register_function(paste)
         server.register_function(copy)
+


### PR DESCRIPTION
pyperclip works on multiple platforms and determines which clipboard program/API to use. I noticed `os.popen` is deprecated, but I wasn't really sure how to do the same thing with `subprocess`.

I've swapped the function names to be consistent with pyperclip's functions.